### PR TITLE
Handle trailing newline characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Added
+- [#5](https://github.com/Studiosity/sip2-ruby/pull/5) Handle trailing newline characters
 
 ## [0.2.2](releases/tag/v0.2.2) - 2020-12-11
 ### Added

--- a/lib/sip2/connection.rb
+++ b/lib/sip2/connection.rb
@@ -16,7 +16,10 @@ module Sip2
     def send_message(message)
       message = with_checksum with_error_detection message
       write_with_timeout message
-      response = read_with_timeout
+      # Read the response and strip any leading newline
+      # - Some ACS terminate messages with /r/n by mistake.
+      #   We need to remove from the front (i.e. buffer remnant from the previous message)
+      response = read_with_timeout&.[](/\A\n?(.*)\z/, 1)
       response if sequence_and_checksum_valid? response
     ensure
       @sequence += 1

--- a/spec/sip2/connection_spec.rb
+++ b/spec/sip2/connection_spec.rb
@@ -33,6 +33,22 @@ describe Sip2::Connection do
       end
     end
 
+    context 'when the returned message has a leading newline character' do
+      it 'strips the newline and returns result' do
+        allow(socket).to receive(:gets).with("\r").and_return "\nmessageAY1AZFBB5\r"
+        expect(socket).to receive(:gets).with "\r"
+        expect(send_message).to eq 'messageAY1AZFBB5'
+      end
+    end
+
+    context 'when the returned message has multiple leading newline characters' do
+      it 'returns nil (fails the checksum)' do
+        allow(socket).to receive(:gets).with("\r").and_return "\n\nmessageAY11234\r"
+        expect(socket).to receive(:gets).with "\r"
+        expect(send_message).to be_nil
+      end
+    end
+
     context 'when the socket is closed before response received (returns nil)' do
       it 'returns nil' do
         allow(socket).to receive(:gets).with("\r").and_return nil


### PR DESCRIPTION
Some ACS appear to terminate messages with "/r/n" by mistake (instead of just "/r" per the spec).

We need to remove (ignore) a newline at the front of the message so it will pass the checksum test (i.e. buffer remnant from the previous message).