### PR TITLE
Fix Ruby 3 support

### DIFF
--- a/lib/sip2/connection.rb
+++ b/lib/sip2/connection.rb
@@ -25,12 +25,12 @@ module Sip2
       @sequence += 1
     end
 
-    def method_missing(method_name, *args)
+    def method_missing(method_name, *args, **kwargs)
       message_class = Messages::Base.message_class_for_method(method_name)
       if message_class.nil?
         super
       else
-        message_class.new(self).action_message(*args)
+        message_class.new(self).action_message(*args, **kwargs)
       end
     end
 

--- a/lib/sip2/messages/base.rb
+++ b/lib/sip2/messages/base.rb
@@ -52,7 +52,7 @@ module Sip2
 
       private
 
-      def build_message(*)
+      def build_message(**)
         raise NotImplementedError, "#{self.class} must implement `build_message` method"
       end
 

--- a/lib/sip2/non_blocking_socket.rb
+++ b/lib/sip2/non_blocking_socket.rb
@@ -30,9 +30,9 @@ module Sip2
           # indicating the connection is in progress.
           socket.connect_nonblock(sockaddr)
         rescue IO::WaitWritable
-          # IO.select will block until the socket is writable or the timeout
-          # is exceeded - whichever comes first.
-          if IO.select(nil, [socket], nil, timeout)
+          # wait_writable waits until the socket is writable without blocking,
+          # and returns self or `nil` when times out
+          if socket.wait_writable(timeout)
             begin
               # Verify there is now a good connection
               socket.connect_nonblock(sockaddr)
@@ -44,7 +44,7 @@ module Sip2
               raise
             end
           else
-            # IO.select returns nil when the socket is not ready before timeout
+            # wait_writable returns nil when the socket is not ready before timeout
             # seconds have elapsed
             socket.close
             raise ConnectionTimeout

--- a/sip2.gemspec
+++ b/sip2.gemspec
@@ -20,6 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.5.0'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/spec/sip2/messages/login_spec.rb
+++ b/spec/sip2/messages/login_spec.rb
@@ -56,4 +56,28 @@ describe Sip2::Messages::Login do
       end
     end
   end
+
+  context 'when connecting to a "real" server' do
+    let(:client) { Sip2::Client.new(host: '127.0.0.1', port: port) }
+    let(:port) { 4321 }
+
+    it 'calls through the connection with the login message' do
+      with_server(port: port) do |server|
+        server_message = nil
+
+        Thread.new do
+          client = server.accept
+          server_message = client.gets "\r"
+          client.write "941AY1AZFDFC\r"
+          client.close
+        end
+
+        response = client.connect do |connection|
+          connection.login username: 'user_name', password: 'pw0rd'
+        end
+        expect(response).to eq true
+        expect(server_message).to eq "9300CNuser_name|COpw0rd|AY1AZF607\r"
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `method_missing` proxy in Sip2::Connection didn't handle passing kwargs through properly and there were no integration tests to check this behaviour. 

Also fixed a potential incompatibility with Ruby 3 Fibers and the IO wait mechanism used to test socket writability.